### PR TITLE
Upgrade to DBT 0.15

### DIFF
--- a/dbt/adapters/athena/relation.py
+++ b/dbt/adapters/athena/relation.py
@@ -1,47 +1,24 @@
-from dbt.adapters.base.relation import BaseRelation
+from dbt.adapters.base.relation import BaseRelation, RelationType, Policy
+from dataclasses import dataclass
 
 
+@dataclass
+class AthenaQuotePolicy(Policy):
+    database: bool = False
+    schema: bool = False
+    identifier: bool = False
+
+
+@dataclass
+class AthenaIncludePolicy(Policy):
+    database: bool = False
+    schema: bool = True
+    identifier: bool = True
+
+
+@dataclass(frozen=True, eq=False, repr=False)
 class AthenaRelation(BaseRelation):
-    DEFAULTS = {
-        'metadata': {
-            'type': 'AthenaRelation'
-        },
-        'quote_character': '',
-        'quote_policy': {
-            'database': False,
-            'schema': False,
-            'identifier': False,
-        },
-        'include_policy': {
-            'database': False,
-            'schema': True,
-            'identifier': True,
-        },
-        'dbt_created': False,
-
-    }
-
-    SCHEMA = {
-        'type': 'object',
-        'properties': {
-            'metadata': {
-                'type': 'object',
-                'properties': {
-                    'type': {
-                        'type': 'string',
-                        'const': 'AthenaRelation',
-                    },
-                },
-            },
-            'type': {
-                'enum': BaseRelation.RelationTypes + [None]
-            },
-            'path': BaseRelation.PATH_SCHEMA,
-            'include_policy': BaseRelation.POLICY_SCHEMA,
-            'quote_policy': BaseRelation.POLICY_SCHEMA,
-            'quote_character': {'type': 'string'},
-            'dbt_created': {'type': 'boolean'},
-        },
-        'required': ['metadata', 'type', 'path', 'include_policy',
-                     'quote_policy', 'quote_character', 'dbt_created']
-    }
+    quote_character: str = ''
+    include_policy: Policy = AthenaIncludePolicy()
+    quote_policy: Policy = AthenaQuotePolicy()
+    sql_before_create: str = ''

--- a/dbt/include/athena/macros/adapters.sql
+++ b/dbt/include/athena/macros/adapters.sql
@@ -65,7 +65,10 @@
   create table
     {{ relation }}
   as (
-    {{ sql }}
+    -- wrapping to select allows to use "with" statements inside "create table"
+    select * from (
+        {{ sql }}
+    )
   );
 {% endmacro %}
 
@@ -79,7 +82,12 @@
 
 {% macro athena__drop_schema(database_name, schema_name) -%}
   {%- call statement('drop_schema') -%}
-    drop schema if exists {{database_name}}.{{schema_name}}
+    drop schema if exists {{schema_name}}
+  {% endcall %}
+{% endmacro %}
+{% macro athena__create_schema(database_name, schema_name) -%}
+  {%- call statement('create_schema') -%}
+    create schema if not exists {{schema_name}}
   {% endcall %}
 {% endmacro %}
 

--- a/dbt/include/athena/macros/materializations/table.sql
+++ b/dbt/include/athena/macros/materializations/table.sql
@@ -42,7 +42,7 @@
       Since dbt uses WRITE_TRUNCATE mode for tables, we only need to drop this thing
       if it is not a table. If it _is_ already a table, then we can overwrite it without downtime
   #}
-  {%- if old_relation_exists is not none -%}
+  {%- if old_relation is not none -%}
       {{ adapter.drop_relation(old_relation) }}
   {%- endif -%}
 


### PR DESCRIPTION
- upgrade to DBT 0.15

  DBT 0.15 contains a lot of classes API changes, so it makes sense to make new changes with Athena adapter already for 0.15

- use AsyncCursor from PyAthena to run queries concurrently.

  it also requires to extract cursor functionality to separate class CursorWrapper to support 

- concurrent queries

  support with statements for models

TODO's in separate PR:

- configure max_workers for AsyncCursor using AthenaCredentials
- add type annotations to all methods
- add tests